### PR TITLE
Development

### DIFF
--- a/src/adapters/osint_sources/__init__.py
+++ b/src/adapters/osint_sources/__init__.py
@@ -9,6 +9,7 @@ from adapters.osint_sources.aboutme import AboutMeScanner
 from adapters.osint_sources.behance import BehanceScanner
 from adapters.osint_sources.devto import DevToScanner
 from adapters.osint_sources.dribbble import DribbbleScanner
+from adapters.osint_sources.facebook import FacebookScanner
 from adapters.osint_sources.gist_github import GitHubGistScanner
 from adapters.osint_sources.github import GitHubScanner
 from adapters.osint_sources.gitlab import GitLabScanner
@@ -30,6 +31,7 @@ __all__ = [
     "BehanceScanner",
     "DevToScanner",
     "DribbbleScanner",
+    "FacebookScanner",
     "GitHubScanner",
     "GitHubGistScanner",
     "GitLabScanner",

--- a/src/adapters/osint_sources/facebook.py
+++ b/src/adapters/osint_sources/facebook.py
@@ -1,0 +1,162 @@
+"""Scanner OSINT: Facebook.
+
+URL:
+- `https://www.facebook.com/<username>`
+
+Extraction strategy (no auth required):
+- Fetches the public profile/page URL via proxy.
+- Parses `<meta>` OG tags for: display name, avatar, description.
+- Detects login redirects (Facebook blocks non-authenticated requests
+  aggressively).
+- Distinguishes between profiles, pages, and non-existent usernames.
+
+Limitations:
+- Facebook is the most aggressive anti-scraping platform. A residential
+  proxy is **strongly** recommended.
+- Most profile content is hidden behind login walls. We can only
+  extract publicly visible OG metadata.
+- Pages (business/creator) tend to expose more data than personal profiles.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from adapters.http_client import build_async_client
+from core.config import AppSettings
+from core.domain.models import SocialProfile
+from core.interfaces.scanner import OSINTScanner
+
+
+def _extract_og(html: str, prop: str) -> str | None:
+    """Extract content from an Open Graph meta tag."""
+    # property="..." content="..."
+    m = re.search(
+        rf'<meta[^>]*property="{re.escape(prop)}"[^>]*content="([^"]*)"',
+        html, re.IGNORECASE,
+    )
+    if m:
+        return m.group(1).strip()
+    # reversed attribute order
+    m2 = re.search(
+        rf'<meta[^>]*content="([^"]*)"[^>]*property="{re.escape(prop)}"',
+        html, re.IGNORECASE,
+    )
+    if m2:
+        return m2.group(1).strip()
+    return None
+
+
+def _extract_title(html: str) -> str | None:
+    """Extract <title> content."""
+    m = re.search(r"<title[^>]*>([^<]+)</title>", html, re.IGNORECASE)
+    return m.group(1).strip() if m else None
+
+
+def _parse_likes(html: str) -> str | None:
+    """Try to extract like/follower count from page HTML."""
+    # Facebook pages sometimes include this in og:description or the HTML.
+    # Pattern: "4,041 likes" or "1.2K likes"
+    m = re.search(r'([\d,.]+[KMkm]?)\s+(?:likes?|followers?)', html, re.IGNORECASE)
+    return m.group(1) if m else None
+
+
+class FacebookScanner(OSINTScanner):
+    _base_url = "https://www.facebook.com"
+
+    def __init__(self, settings: AppSettings | None = None) -> None:
+        self._settings = settings or AppSettings()
+
+    async def scan(self, username: str) -> SocialProfile:
+        url = f"{self._base_url}/{username}"
+
+        headers = {
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Sec-Fetch-Dest": "document",
+            "Sec-Fetch-Mode": "navigate",
+            "Sec-Fetch-Site": "none",
+        }
+
+        async with build_async_client(self._settings, extra_headers=headers) as client:
+            response = await client.get(url, follow_redirects=True)
+
+        html = response.text or ""
+        final_url = str(response.url)
+        status = response.status_code
+
+        metadata: dict[str, Any] = {
+            "status_code": status,
+            "final_url": final_url,
+        }
+
+        bio: str | None = None
+        image_url: str | None = None
+        exists = False
+
+        # Facebook redirects to login for most requests.
+        is_login_redirect = "/login" in final_url or "/checkpoint" in final_url
+        # Generic "page not found" or profile doesn't exist.
+        is_not_found = status == 404
+
+        if is_login_redirect:
+            metadata["blocked"] = True
+            metadata["note"] = (
+                "Facebook redirected to login — residential proxy recommended."
+            )
+        elif not is_not_found and status == 200 and html:
+            # ── Extract OG metadata ──
+            og_title = _extract_og(html, "og:title")
+            og_desc = _extract_og(html, "og:description")
+            og_image = _extract_og(html, "og:image")
+            og_type = _extract_og(html, "og:type")
+            page_title = _extract_title(html)
+
+            # Heuristic: if og:title exists and isn't a generic FB page,
+            # the profile/page exists.
+            generic_titles = {
+                "facebook", "facebook - log in or sign up",
+                "facebook – log in or sign up",
+                "log in to facebook", "page not found",
+            }
+
+            title_to_check = (og_title or page_title or "").lower().strip()
+
+            if title_to_check and title_to_check not in generic_titles:
+                exists = True
+
+                if og_title:
+                    metadata["name"] = og_title
+                if og_desc:
+                    bio = og_desc
+                    metadata["description"] = og_desc
+                if og_image:
+                    image_url = og_image
+                if og_type:
+                    metadata["type"] = og_type  # "profile" or "page"
+                if page_title:
+                    metadata["title"] = page_title
+
+                # Try to get like/follower counts.
+                likes = _parse_likes(html)
+                if likes:
+                    metadata["likes"] = likes
+
+                # Detect page vs profile.
+                if og_type and "profile" in og_type.lower():
+                    metadata["account_type"] = "profile"
+                elif og_type and "page" in og_type.lower():
+                    metadata["account_type"] = "page"
+                elif "likes" in metadata:
+                    metadata["account_type"] = "page"
+
+        return SocialProfile(
+            url=f"{self._base_url}/{username}",
+            username=username,
+            network_name="facebook",
+            exists=exists,
+            metadata=metadata,
+            bio=bio,
+            image_url=image_url,
+        )

--- a/src/adapters/osint_sources/facebook.py
+++ b/src/adapters/osint_sources/facebook.py
@@ -29,22 +29,24 @@ from core.domain.models import SocialProfile
 from core.interfaces.scanner import OSINTScanner
 
 
-def _extract_og(html: str, prop: str) -> str | None:
+def _extract_og(html_str: str, prop: str) -> str | None:
     """Extract content from an Open Graph meta tag."""
+    import html as html_mod
+
     # property="..." content="..."
     m = re.search(
         rf'<meta[^>]*property="{re.escape(prop)}"[^>]*content="([^"]*)"',
-        html, re.IGNORECASE,
+        html_str, re.IGNORECASE,
     )
     if m:
-        return m.group(1).strip()
+        return html_mod.unescape(m.group(1).strip())
     # reversed attribute order
     m2 = re.search(
         rf'<meta[^>]*content="([^"]*)"[^>]*property="{re.escape(prop)}"',
-        html, re.IGNORECASE,
+        html_str, re.IGNORECASE,
     )
     if m2:
-        return m2.group(1).strip()
+        return html_mod.unescape(m2.group(1).strip())
     return None
 
 

--- a/src/adapters/osint_sources/instagram.py
+++ b/src/adapters/osint_sources/instagram.py
@@ -27,24 +27,29 @@ from core.domain.models import SocialProfile
 from core.interfaces.scanner import OSINTScanner
 
 
-def _extract_og_content(html: str, property_name: str) -> str | None:
-    """Extract content from an Open Graph meta tag."""
+def _extract_og_content(html_str: str, property_name: str) -> str | None:
+    """Extract content from an Open Graph meta tag.
+
+    Returns the unescaped value (``&amp;`` → ``&``, etc.).
+    """
+    import html as html_mod
+
     # Match both property="..." and content="..." in either order.
     pattern = re.compile(
         rf'<meta[^>]*property="{re.escape(property_name)}"[^>]*content="([^"]*)"',
         re.IGNORECASE,
     )
-    match = pattern.search(html)
+    match = pattern.search(html_str)
     if match:
-        return match.group(1).strip()
+        return html_mod.unescape(match.group(1).strip())
     # Try reversed attribute order.
     pattern2 = re.compile(
         rf'<meta[^>]*content="([^"]*)"[^>]*property="{re.escape(property_name)}"',
         re.IGNORECASE,
     )
-    match2 = pattern2.search(html)
+    match2 = pattern2.search(html_str)
     if match2:
-        return match2.group(1).strip()
+        return html_mod.unescape(match2.group(1).strip())
     return None
 
 

--- a/src/adapters/report_exporter.py
+++ b/src/adapters/report_exporter.py
@@ -862,5 +862,7 @@ def export_person_pdf(*, person: PersonEntity, output_path: Path, language: Lang
     logging.getLogger("fontTools").setLevel(logging.ERROR)
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=".*fsSelection.*")
+        warnings.filterwarnings("ignore", message=".*instantiateVariableFont.*")
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
         HTML(string=html, base_url=base_url).write_pdf(str(output_path))
     return output_path

--- a/src/adapters/report_exporter.py
+++ b/src/adapters/report_exporter.py
@@ -666,10 +666,17 @@ def _extract_identity_card(person: PersonEntity) -> dict[str, object]:
             if not card["bio"] and (md.get("bio") or p.bio):
                 card["bio"] = md.get("bio") or p.bio
 
+        # Facebook: extract name, bio from metadata.
+        elif net == "facebook" and md:
+            if not card["name"] and md.get("name"):
+                card["name"] = md["name"]
+            if not card["bio"] and (md.get("description") or p.bio):
+                card["bio"] = md.get("description") or p.bio
+
     # ── Fallback avatar: try image_url from confirmed profiles ──
-    # Priority order: instagram > telegram > twitter/x > any other.
+    # Priority order: instagram > facebook > telegram > twitter/x > any other.
     if not card["avatar_url"]:
-        priority_order = ["instagram", "telegram", "x", "twitter"]
+        priority_order = ["instagram", "facebook", "telegram", "x", "twitter"]
         avatar_candidates: list[tuple[int, str]] = []
         for p in person.profiles:
             if not p.exists or not p.image_url:

--- a/src/adapters/report_exporter.py
+++ b/src/adapters/report_exporter.py
@@ -828,5 +828,14 @@ def export_person_pdf(*, person: PersonEntity, output_path: Path, language: Lang
             "PDF export is disabled."
         )
 
-    HTML(string=html, base_url=base_url).write_pdf(str(output_path))
+    import logging
+    import warnings
+
+    # Suppress noisy fontTools warnings ("fsSelection bit 5 (bold)…")
+    # and WeasyPrint's own verbose logging.
+    logging.getLogger("weasyprint").setLevel(logging.ERROR)
+    logging.getLogger("fontTools").setLevel(logging.ERROR)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=".*fsSelection.*")
+        HTML(string=html, base_url=base_url).write_pdf(str(output_path))
     return output_path

--- a/src/adapters/report_exporter.py
+++ b/src/adapters/report_exporter.py
@@ -153,6 +153,12 @@ _STRINGS: dict[Language, dict[str, object]] = {
             "records": "Records",
             "classes": "Data classes",
         },
+        "ai_section_identity": "Identity",
+        "ai_section_geotemporal": "Geo-Temporal",
+        "ai_section_psychological": "OCEAN Profile",
+        "ai_section_technical": "Technical / Professional",
+        "ai_section_ideology": "Ideology",
+        "ai_section_opsec": "OpSec / Attack Surface",
     },
     Language.SPANISH: {
         "lang_code": "es",
@@ -248,6 +254,12 @@ _STRINGS: dict[Language, dict[str, object]] = {
             "records": "Registros",
             "classes": "Datos expuestos",
         },
+        "ai_section_identity": "Identidad",
+        "ai_section_geotemporal": "Geo-Temporal",
+        "ai_section_psychological": "Perfil OCEAN",
+        "ai_section_technical": "Técnico / Profesional",
+        "ai_section_ideology": "Ideología",
+        "ai_section_opsec": "OpSec / Superficie de Ataque",
     },
 
     Language.PORTUGUESE: {
@@ -344,6 +356,12 @@ _STRINGS: dict[Language, dict[str, object]] = {
             "records": "Registros",
             "classes": "Dados expostos",
         },
+        "ai_section_identity": "Identidade",
+        "ai_section_geotemporal": "Geo-Temporal",
+        "ai_section_psychological": "Perfil OCEAN",
+        "ai_section_technical": "Técnico / Profissional",
+        "ai_section_ideology": "Ideologia",
+        "ai_section_opsec": "OpSec / Superfície de Ataque",
     },
     Language.ARABIC: {
         "lang_code": "ar",
@@ -439,6 +457,12 @@ _STRINGS: dict[Language, dict[str, object]] = {
             "records": "السجلات",
             "classes": "فئات البيانات",
         },
+        "ai_section_identity": "الهوية",
+        "ai_section_geotemporal": "الجغرافي-الزمني",
+        "ai_section_psychological": "ملف OCEAN",
+        "ai_section_technical": "تقني / مهني",
+        "ai_section_ideology": "الأيديولوجيا",
+        "ai_section_opsec": "أمن العمليات / سطح الهجوم",
     },
     Language.RUSSIAN: {
         "lang_code": "ru",
@@ -534,6 +558,12 @@ _STRINGS: dict[Language, dict[str, object]] = {
             "records": "Записи",
             "classes": "Классы данных",
         },
+        "ai_section_identity": "Идентичность",
+        "ai_section_geotemporal": "Гео-Темпоральный",
+        "ai_section_psychological": "Профиль OCEAN",
+        "ai_section_technical": "Технический / Профессиональный",
+        "ai_section_ideology": "Идеология",
+        "ai_section_opsec": "OpSec / Поверхность атаки",
     },}
 
 

--- a/src/adapters/report_exporter.py
+++ b/src/adapters/report_exporter.py
@@ -689,7 +689,8 @@ def _extract_identity_card(person: PersonEntity) -> dict[str, object]:
             avatar_candidates.append((rank, p.image_url))
         if avatar_candidates:
             avatar_candidates.sort(key=lambda x: x[0])
-            card["avatar_url"] = avatar_candidates[0][1]
+            import html as html_mod
+            card["avatar_url"] = html_mod.unescape(avatar_candidates[0][1])
 
     card["emails"] = sorted(emails_set)
     card["handles"] = sorted(handles_set)

--- a/src/adapters/report_exporter.py
+++ b/src/adapters/report_exporter.py
@@ -659,6 +659,31 @@ def _extract_identity_card(person: PersonEntity) -> dict[str, object]:
             if not card["bio"]:
                 card["bio"] = md.get("bio")
 
+        # Instagram: extract bio, name, and avatar from metadata.
+        elif net == "instagram" and md:
+            if not card["name"] and md.get("name"):
+                card["name"] = md["name"]
+            if not card["bio"] and (md.get("bio") or p.bio):
+                card["bio"] = md.get("bio") or p.bio
+
+    # ── Fallback avatar: try image_url from confirmed profiles ──
+    # Priority order: instagram > telegram > twitter/x > any other.
+    if not card["avatar_url"]:
+        priority_order = ["instagram", "telegram", "x", "twitter"]
+        avatar_candidates: list[tuple[int, str]] = []
+        for p in person.profiles:
+            if not p.exists or not p.image_url:
+                continue
+            net = (p.network_name or "").lower()
+            try:
+                rank = priority_order.index(net)
+            except ValueError:
+                rank = len(priority_order)
+            avatar_candidates.append((rank, p.image_url))
+        if avatar_candidates:
+            avatar_candidates.sort(key=lambda x: x[0])
+            card["avatar_url"] = avatar_candidates[0][1]
+
     card["emails"] = sorted(emails_set)
     card["handles"] = sorted(handles_set)
     card["confirmed_networks"] = sorted(networks_set)

--- a/src/adapters/templates/report.html
+++ b/src/adapters/templates/report.html
@@ -856,17 +856,18 @@
         <div class="footer-note">{{ strings.analysis_footer_note }}</div>
 
         {# ── AI Sections (parsed) ── #}
-        {% if ai_sections %}
+        {% set has_real_sections = ai_sections.identity or ai_sections.geotemporal or ai_sections.psychological or ai_sections.technical or ai_sections.ideology or ai_sections.opsec %}
+        {% if has_real_sections %}
           {% if ai_sections.identity %}
           <div class="page-break"></div>
-          <h2 class="section-title">🆔 {{ strings.toc_entries[0].label.split(" // ")[1] if strings.toc_entries|length > 0 else "Identity" }}</h2>
+          <h2 class="section-title">🆔 {{ strings.ai_section_identity | default("Identity") }}</h2>
           <div class="card ai-section-content">
             {{ ai_sections.identity | markdown }}
           </div>
           {% endif %}
 
           {% if ai_sections.geotemporal %}
-          <h2 class="section-title">🌍 {{ strings.toc_entries[0].label.split(" // ")[1] if strings.toc_entries|length > 1 else "Geo-Temporal" }}</h2>
+          <h2 class="section-title">🌍 {{ strings.ai_section_geotemporal | default("Geo-Temporal") }}</h2>
           <div class="card ai-section-content">
             {{ ai_sections.geotemporal | markdown }}
           </div>
@@ -874,14 +875,14 @@
 
           {% if ai_sections.psychological %}
           <div class="page-break"></div>
-          <h2 class="section-title">🧠 OCEAN Profile</h2>
+          <h2 class="section-title">🧠 {{ strings.ai_section_psychological | default("OCEAN Profile") }}</h2>
           <div class="card ai-section-content">
             {{ ai_sections.psychological | markdown }}
           </div>
           {% endif %}
 
           {% if ai_sections.technical %}
-          <h2 class="section-title">💻 Technical / Professional</h2>
+          <h2 class="section-title">💻 {{ strings.ai_section_technical | default("Technical / Professional") }}</h2>
           <div class="card ai-section-content">
             {{ ai_sections.technical | markdown }}
           </div>
@@ -889,14 +890,14 @@
 
           {% if ai_sections.ideology %}
           <div class="page-break"></div>
-          <h2 class="section-title">⚖️ Ideology</h2>
+          <h2 class="section-title">⚖️ {{ strings.ai_section_ideology | default("Ideology") }}</h2>
           <div class="card ai-section-content">
             {{ ai_sections.ideology | markdown }}
           </div>
           {% endif %}
 
           {% if ai_sections.opsec %}
-          <h2 class="section-title">⚠️ OpSec / Attack Surface</h2>
+          <h2 class="section-title">⚠️ {{ strings.ai_section_opsec | default("OpSec / Attack Surface") }}</h2>
           <div class="card ai-section-content">
             {{ ai_sections.opsec | markdown }}
           </div>

--- a/src/adapters/templates/report.html
+++ b/src/adapters/templates/report.html
@@ -58,6 +58,9 @@
         margin: 0;
         font-size: 10pt;
         line-height: 1.55;
+        overflow-wrap: break-word;
+        word-wrap: break-word;
+        word-break: break-word;
       }
 
       /* ═══════════════════════════════════════════════
@@ -269,6 +272,8 @@
         padding: 16px 18px;
         box-shadow: 0 2px 8px var(--shadow);
         margin-bottom: 14px;
+        page-break-inside: avoid;
+        overflow: hidden;
       }
 
       .card-accent {
@@ -438,13 +443,18 @@
       .ai-section-content {
         font-size: 10pt;
         line-height: 1.6;
+        overflow: hidden;
+        overflow-wrap: break-word;
+        word-break: break-word;
+        page-break-inside: auto; /* override .card — these can be multi-page */
       }
 
       .ai-section-content table {
         width: 100%;
         border-collapse: collapse;
         margin: 8px 0;
-        font-size: 10px;
+        font-size: 9px;
+        table-layout: fixed;
       }
 
       .ai-section-content th {
@@ -461,6 +471,9 @@
         padding: 6px 10px;
         border-bottom: 1px solid var(--border);
         vertical-align: top;
+        overflow-wrap: break-word;
+        word-break: break-word;
+        hyphens: auto;
       }
 
       .ai-section-content ul, .ai-section-content ol {
@@ -474,6 +487,12 @@
 
       .ai-section-content p {
         margin: 6px 0;
+        overflow-wrap: break-word;
+      }
+
+      .ai-section-content code {
+        font-size: 9px;
+        word-break: break-all;
       }
 
       .ai-section-content strong {
@@ -514,6 +533,9 @@
         border-collapse: collapse;
         margin-top: 10px;
         font-size: 10px;
+        table-layout: fixed;
+        word-break: break-word;
+        overflow-wrap: break-word;
       }
 
       thead th {
@@ -525,16 +547,23 @@
         font-size: 9px;
         font-weight: 700;
         text-align: left;
+        overflow: hidden;
       }
 
       tbody td {
         padding: 7px 10px;
         border-bottom: 1px solid rgba(148, 163, 184, 0.20);
         vertical-align: top;
+        overflow-wrap: break-word;
+        word-break: break-word;
       }
 
       tbody tr:nth-child(even) {
         background: var(--surface-alt);
+      }
+
+      tbody tr {
+        page-break-inside: avoid;
       }
 
       .badge-confirmed {
@@ -893,6 +922,13 @@
       <div class="card">
         <p class="muted">{{ strings.confirmed_hint }} — {{ profiles_confirmed_count }} profiles</p>
         <table>
+          <colgroup>
+            <col style="width: 18%;" />
+            <col style="width: 18%;" />
+            <col style="width: 14%;" />
+            <col style="width: 12%;" />
+            <col style="width: 38%;" />
+          </colgroup>
           <thead>
             <tr>
               <th>{{ strings.confirmed_headers.network }}</th>
@@ -909,7 +945,7 @@
                 <td><strong>{{ p.username }}</strong></td>
                 <td>{{ p._source }}</td>
                 <td class="badge-confirmed">{{ strings.status_confirmed }}</td>
-                <td><a href="{{ p.url }}">{{ p.url[:55] }}{% if p.url|length > 55 %}…{% endif %}</a></td>
+                <td style="font-size:8px;"><a href="{{ p.url }}">{{ p.url[:45] }}{% if p.url|length > 45 %}…{% endif %}</a></td>
               </tr>
             {% endfor %}
           </tbody>
@@ -929,6 +965,11 @@
           {% for source, items in unconfirmed_by_source %}
             <h3 class="source-title">{{ strings.unconfirmed_source_label }}: {{ source }} ({{ items|length }})</h3>
             <table>
+              <colgroup>
+                <col style="width: 25%;" />
+                <col style="width: 25%;" />
+                <col style="width: 50%;" />
+              </colgroup>
               <thead>
                 <tr>
                   <th>{{ strings.unconfirmed_headers.network }}</th>
@@ -941,7 +982,7 @@
                   <tr>
                     <td>{{ p.network_name }}</td>
                     <td>{{ p.username }}</td>
-                    <td><a href="{{ p.url }}">{{ p.url[:60] }}{% if p.url|length > 60 %}…{% endif %}</a></td>
+                    <td style="font-size:8px;"><a href="{{ p.url }}">{{ p.url[:50] }}{% if p.url|length > 50 %}…{% endif %}</a></td>
                   </tr>
                 {% endfor %}
               </tbody>

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -1416,14 +1416,38 @@ async def _agent_async(
             f"({result.total_steps}/{max_steps}).\n"
         )
 
-    # Show profiles table.
-    if person.profiles:
-        _print_profiles_table(person=person, primary_usernames=[objective])
-
-    # Show analysis.
+    # Show analysis first — it's the main deliverable in agent mode.
     if person.analysis:
         panel = build_analysis_panel(person.analysis)
         console.print(panel)
+
+    # Show only confirmed profiles (the full table goes into the PDF).
+    confirmed = [p for p in person.profiles if p.exists]
+    if confirmed:
+        from rich.table import Table as RichTable
+
+        tbl = RichTable(
+            title="Confirmed Profiles",
+            title_style="bold bright_cyan",
+            border_style="dim",
+            show_lines=False,
+        )
+        tbl.add_column("Network", style="bold")
+        tbl.add_column("Username")
+        tbl.add_column("URL", style="dim")
+        for p in confirmed:
+            tbl.add_row(
+                p.network_name,
+                p.username,
+                str(p.url)[:72] + ("…" if len(str(p.url)) > 72 else ""),
+            )
+        console.print()
+        console.print(tbl)
+        console.print(
+            f"\n  [dim]{len(confirmed)} confirmed / "
+            f"{len(person.profiles)} total scanned "
+            f"(full table in PDF)[/dim]\n"
+        )
 
     # Exports.
     _handle_exports(

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -1324,22 +1324,39 @@ async def _agent_async(
 
     def on_step(step: AgentStep) -> None:
         if step.tool_name:
-            args_str = ", ".join(f'{k}="{v}"' for k, v in step.tool_args.items())
-            icon = "📋" if step.tool_name == "generate_report" else "🔍"
-            console.print(
-                f"  {icon} [bold]Step {step.step_number}/{max_steps}:[/bold] "
-                f"[cyan]{step.tool_name}[/cyan]({args_str})"
-            )
-            if step.tool_result and step.tool_name != "generate_report":
-                try:
-                    data = json.loads(step.tool_result)
-                    confirmed = data.get("confirmed", "?")
-                    total = data.get("total_scanned", "?")
-                    console.print(
-                        f"     → [green]{confirmed}[/green] confirmed / {total} scanned"
-                    )
-                except Exception:
-                    pass
+            if step.tool_name == "generate_report":
+                # Don't dump the full summary; it's shown in the panel after.
+                confidence = step.tool_args.get("confidence", "?")
+                n_highlights = 0
+                raw_hl = step.tool_args.get("highlights", "")
+                if isinstance(raw_hl, list):
+                    n_highlights = len(raw_hl)
+                elif isinstance(raw_hl, str):
+                    try:
+                        n_highlights = len(json.loads(raw_hl))
+                    except Exception:
+                        n_highlights = raw_hl.count("',") + (1 if raw_hl.strip() else 0)
+                console.print(
+                    f"  📋 [bold]Step {step.step_number}/{max_steps}:[/bold] "
+                    f"[cyan]generate_report[/cyan]"
+                    f"(confidence={confidence}, highlights={n_highlights})"
+                )
+            else:
+                args_str = ", ".join(f'{k}="{v}"' for k, v in step.tool_args.items())
+                console.print(
+                    f"  🔍 [bold]Step {step.step_number}/{max_steps}:[/bold] "
+                    f"[cyan]{step.tool_name}[/cyan]({args_str})"
+                )
+                if step.tool_result:
+                    try:
+                        data = json.loads(step.tool_result)
+                        confirmed = data.get("confirmed", "?")
+                        total = data.get("total_scanned", "?")
+                        console.print(
+                            f"     → [green]{confirmed}[/green] confirmed / {total} scanned"
+                        )
+                    except Exception:
+                        pass
         elif step.reasoning:
             console.print(
                 f"\n  🧠 [bold]Step {step.step_number}/{max_steps}:[/bold] [dim]Reasoning...[/dim]"

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -1426,6 +1426,15 @@ async def _agent_async(
     if confirmed:
         from rich.table import Table as RichTable
 
+        # Deduplicate by (network, username).
+        seen: set[tuple[str, str]] = set()
+        unique_confirmed: list = []
+        for p in confirmed:
+            key = (p.network_name, p.username)
+            if key not in seen:
+                seen.add(key)
+                unique_confirmed.append(p)
+
         tbl = RichTable(
             title="Confirmed Profiles",
             title_style="bold bright_cyan",
@@ -1435,7 +1444,7 @@ async def _agent_async(
         tbl.add_column("Network", style="bold")
         tbl.add_column("Username")
         tbl.add_column("URL", style="dim")
-        for p in confirmed:
+        for p in unique_confirmed:
             tbl.add_row(
                 p.network_name,
                 p.username,
@@ -1444,7 +1453,7 @@ async def _agent_async(
         console.print()
         console.print(tbl)
         console.print(
-            f"\n  [dim]{len(confirmed)} confirmed / "
+            f"\n  [dim]{len(unique_confirmed)} confirmed / "
             f"{len(person.profiles)} total scanned "
             f"(full table in PDF)[/dim]\n"
         )

--- a/src/cli/ui_components.py
+++ b/src/cli/ui_components.py
@@ -52,11 +52,20 @@ def build_analysis_panel(report: AnalysisReport) -> Panel:
 
     title = Text("AI Analysis", style="bold bright_green")
     body = Text()
-    body.append(report.summary.strip() + "\n\n")
-    if report.highlights:
-        body.append("Highlights:\n", style="bold bright_green")
+    body.append(report.summary.strip() + "\n")
+
+    # Only append highlights if they aren't already embedded in the summary.
+    summary_lower = report.summary.lower()
+    highlights_in_summary = (
+        "highlight" in summary_lower
+        or "puntos clave" in summary_lower
+        or "hallazgos" in summary_lower
+    )
+    if report.highlights and not highlights_in_summary:
+        body.append("\nHighlights:\n", style="bold bright_green")
         for h in report.highlights:
             body.append(f"- {h}\n")
+
     body.append(f"\nConfidence: {report.confidence:.2f}")
     if report.model:
         body.append(f"\nModel: {report.model}", style="dim")

--- a/src/core/services/identity_pipeline.py
+++ b/src/core/services/identity_pipeline.py
@@ -25,6 +25,7 @@ from adapters.osint_sources import (
     BehanceScanner,
     DevToScanner,
     DribbbleScanner,
+    FacebookScanner,
     GitHubGistScanner,
     GitHubScanner,
     GitLabScanner,
@@ -119,6 +120,7 @@ _USERNAME_SCANNERS = (
     BehanceScanner,
     XScanner,
     InstagramScanner,
+    FacebookScanner,
 )
 
 _EMAIL_SCANNERS = (


### PR DESCRIPTION
# PR: `development` → `main` — v2.0.0

## 🤖 Agentic AI Mode (`osint-d2 agent`)

The flagship feature of v2.0.0: autonomous OSINT investigations powered by LLM function calling.

- **5 agent tools**: `scan_username`, `scan_email`, `fetch_url`, `breach_check`, `generate_report`
- The AI decides what to investigate, discovers new leads, and pivots automatically
- Generates a structured 6-dimension cognitive profile when evidence is sufficient
- Works with DeepSeek, Groq, OpenRouter, HuggingFace, and any OpenAI-compatible provider
- Available in the CLI and the interactive wizard

```bash
osint-d2 agent "torvalds" --breach-check --export-pdf --export-json -l es
```

## 🛡️ Trust Anchors

Define verified identity sources to automatically filter false positives.

```bash
osint-d2 agent "janedoe" --trust instagram:janedoe --trust email:jane@gmail.com
```

- Compares discovered profiles against trusted sources
- Automatically discards mismatched identities
- Supports network:username and email:user@domain formats

## 🌐 New Scanners

- **Facebook** — profile/page detection, name, avatar, bio, likes extraction
- **Instagram** — public profile scraping (bio, followers, avatar via og:tags)

Both scanners use OG meta tag extraction with HTML entity unescaping for clean URLs.

## 🔒 ScrapingAnt Proxy Integration

- Residential and datacenter proxy modes
- Country-specific routing (e.g., `--proxy-country us`)
- Auto-detected from `.env` configuration

## 📄 Premium PDF Dossier

- Redesigned report template with dark theme and professional layout
- **Profile avatar on cover page** (Instagram → Facebook → Telegram priority)
- Fixed table overflow and page-break issues
- Localized AI section titles across 5 languages (EN, ES, PT, AR, RU)
- Suppressed noisy WeasyPrint/fontTools warnings in CLI output

## 🧙 Interactive Wizard Improvements

- Agent mode integrated into the wizard flow
- Trust anchor configuration via interactive prompts
- Proxy settings (mode, country) in wizard
- Streamlined CLI output: analysis-first, compact confirmed-only table

## 🧪 Testing & Quality

- 143 tests passing (75 new tests for agent_engine, identity_pipeline, trust_anchor)
- CI workflow with pytest
- All ruff lint errors resolved (121 fixed)

## 🔧 UX & Polish

- Agent CLI output no longer dumps the full AI summary in step logs
- Confirmed profiles table is deduplicated and shows only YES results
- AI analysis panel displayed before the table (it's the main deliverable)
- Duplicate highlights detection (skips if already in summary)
- Clean terminal output — no more fontTools/WeasyPrint noise

---

## Commits (33)

### Features
- `feat: add agentic AI mode (osint-d2 agent)`
- `feat: add agent mode to wizard + README documentation`
- `feat: add fetch_url agent tool + enrich HTML extraction`
- `feat: add trust anchors for identity verification (--trust)`
- `feat: add Instagram scanner (public profile scraping)`
- `feat: add Facebook profile/page scanner`
- `feat: add proxy, trust anchors to wizard + hunt command`
- `feat: integrate ScrapingAnt proxy support (residential + datacenter)`
- `feat: premium PDF dossier redesign`
- `feat: show profile avatar on PDF cover page (Instagram priority)`
- `feat: add pytest suite + CI workflow`

### Fixes
- `fix: unescape HTML entities in OG image URLs (avatar on PDF cover)`
- `fix: stop dumping full AI summary twice in agent mode CLI`
- `fix: AI sections used wrong titles — all showed 'Intelligence Summary'`
- `fix: PDF layout overflow — table-layout:fixed, word-break, page-break-inside`
- `fix: suppress WeasyPrint/fontTools warnings during PDF export`
- `fix: wizard trust anchors + AI analysis error handling`
- `fix: support email trust anchors + name contradiction detection`
- `fix: force report generation when agent exhausts max_steps`
- `fix: correct ScrapingAnt proxy URL format`

### UX
- `ux: agent mode — show analysis first, compact confirmed-only table`
- `ux: fix duplicate highlights in panel + dedup confirmed profiles`

### Docs & Quality
- `docs: rewrite README + .env.example`
- `docs: remove personal data from README examples`
- `test: add 75 new tests for agent_engine, identity_pipeline, trust_anchor`
- `fix: resolve 8 ruff lint errors in test files`
- `style: fix all ruff lint errors (121 total)`
