### PR TITLE
fix(security): add SSRF guard to fetch_url agent tool (#25)

### DIFF
--- a/src/core/services/agent_tools.py
+++ b/src/core/services/agent_tools.py
@@ -273,6 +273,14 @@ async def execute_tool(
             return json.dumps({"error": "url is required"})
         if not (url.startswith("http://") or url.startswith("https://")):
             url = f"https://{url}"
+
+        # SSRF guard — block private/internal/IMDS targets (issue #25)
+        from core.services.url_guard import SSRFBlockedError, validate_url
+        try:
+            url = validate_url(url)
+        except (SSRFBlockedError, ValueError) as exc:
+            return json.dumps({"url": url, "error": f"SSRF blocked: {exc}"})
+
         from adapters.http_client import build_async_client, extract_html_metadata
         try:
             async with build_async_client(settings) as client:

--- a/src/core/services/url_guard.py
+++ b/src/core/services/url_guard.py
@@ -1,0 +1,120 @@
+"""SSRF protection for agent-controlled URL fetching.
+
+Blocks requests to private/internal networks, loopback addresses,
+link-local ranges, and known cloud IMDS endpoints to prevent
+Server-Side Request Forgery when the LLM is influenced by
+attacker-controlled profile data (e.g. a GitHub bio containing
+``http://169.254.169.254/latest/meta-data/``).
+
+See: https://github.com/Doble-2/osint-d2/issues/25
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+# ── Blocked hostnames (case-insensitive) ──────────────────────────────────
+
+_BLOCKED_HOSTS: frozenset[str] = frozenset({
+    "localhost",
+    "0.0.0.0",
+    # Cloud IMDS endpoints
+    "metadata.google.internal",         # GCP
+    "metadata.goog",                    # GCP alternative
+    "169.254.169.254",                  # AWS / Azure / most clouds
+    "metadata.azure.com",              # Azure
+})
+
+# ── Private / reserved IP ranges ──────────────────────────────────────────
+
+_PRIVATE_RANGES: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = (
+    ipaddress.ip_network("0.0.0.0/8"),        # "this" network
+    ipaddress.ip_network("10.0.0.0/8"),       # RFC 1918
+    ipaddress.ip_network("100.64.0.0/10"),    # carrier-grade NAT
+    ipaddress.ip_network("127.0.0.0/8"),      # loopback
+    ipaddress.ip_network("169.254.0.0/16"),   # link-local / IMDS
+    ipaddress.ip_network("172.16.0.0/12"),    # RFC 1918
+    ipaddress.ip_network("192.0.0.0/24"),     # IETF protocol assignments
+    ipaddress.ip_network("192.168.0.0/16"),   # RFC 1918
+    ipaddress.ip_network("198.18.0.0/15"),    # benchmarking
+    # IPv6
+    ipaddress.ip_network("::1/128"),          # loopback
+    ipaddress.ip_network("fc00::/7"),         # unique local
+    ipaddress.ip_network("fe80::/10"),        # link-local
+)
+
+
+def _is_private_ip(host: str) -> bool:
+    """Return True if *host* is a literal IP in a private/reserved range."""
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return any(addr in net for net in _PRIVATE_RANGES)
+
+
+def _resolves_to_private(hostname: str) -> bool:
+    """Resolve *hostname* via DNS and check whether any result is private.
+
+    This catches cases like a custom domain that DNS-resolves to 127.0.0.1
+    or an internal IP (DNS rebinding / split-horizon scenarios).
+    """
+    try:
+        results = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    except (socket.gaierror, OSError):
+        # DNS resolution failed — allow the request to proceed (httpx will
+        # raise its own error).
+        return False
+
+    for _family, _type, _proto, _canonname, sockaddr in results:
+        ip_str = sockaddr[0]
+        if _is_private_ip(ip_str):
+            return True
+    return False
+
+
+class SSRFBlockedError(Exception):
+    """Raised when a URL targets a blocked host or private network."""
+
+
+def validate_url(url: str) -> str:
+    """Validate *url* for SSRF safety and return the normalised URL.
+
+    Raises
+    ------
+    SSRFBlockedError
+        If the URL targets a private/internal address or a blocked host.
+    ValueError
+        If the URL is malformed.
+    """
+    parsed = urlparse(url)
+    scheme = (parsed.scheme or "").lower()
+
+    if scheme not in ("http", "https"):
+        raise ValueError(f"Unsupported URL scheme: {scheme!r}")
+
+    host = (parsed.hostname or "").lower().rstrip(".")
+    if not host:
+        raise ValueError("URL has no hostname")
+
+    # 1) Blocked hostname check
+    if host in _BLOCKED_HOSTS:
+        raise SSRFBlockedError(
+            f"Blocked: {host!r} is a known internal/IMDS hostname"
+        )
+
+    # 2) Literal IP check
+    if _is_private_ip(host):
+        raise SSRFBlockedError(
+            f"Blocked: {host!r} is in a private/reserved IP range"
+        )
+
+    # 3) DNS resolution check (catches DNS rebinding to internal IPs)
+    if _resolves_to_private(host):
+        raise SSRFBlockedError(
+            f"Blocked: {host!r} resolves to a private/reserved IP address"
+        )
+
+    return url

--- a/tests/test_ssrf_guard.py
+++ b/tests/test_ssrf_guard.py
@@ -1,0 +1,262 @@
+"""Tests for the SSRF guard (issue #25).
+
+Covers:
+- Blocked IMDS endpoints (AWS, GCP, Azure)
+- Private IP ranges (RFC 1918, loopback, link-local)
+- IPv6 private ranges
+- DNS rebinding to private IPs
+- Valid public URLs pass through
+- Integration with fetch_url in execute_tool
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core.services.url_guard import SSRFBlockedError, validate_url
+
+
+# ---------------------------------------------------------------------------
+# Direct validate_url tests
+# ---------------------------------------------------------------------------
+
+
+class TestBlockedIMDSEndpoints:
+    """IMDS endpoints must be blocked regardless of path."""
+
+    def test_aws_imds(self):
+        with pytest.raises(SSRFBlockedError, match="169.254.169.254"):
+            validate_url("http://169.254.169.254/latest/meta-data/")
+
+    def test_aws_imds_credentials(self):
+        with pytest.raises(SSRFBlockedError):
+            validate_url(
+                "http://169.254.169.254/latest/meta-data/iam/security-credentials/my-role"
+            )
+
+    def test_gcp_metadata(self):
+        with pytest.raises(SSRFBlockedError, match="metadata.google.internal"):
+            validate_url(
+                "http://metadata.google.internal/computeMetadata/v1/"
+            )
+
+    def test_gcp_metadata_alt(self):
+        with pytest.raises(SSRFBlockedError, match="metadata.goog"):
+            validate_url("http://metadata.goog/computeMetadata/v1/")
+
+    def test_azure_metadata(self):
+        with pytest.raises(SSRFBlockedError):
+            validate_url(
+                "http://169.254.169.254/metadata/instance?api-version=2021-02-01"
+            )
+
+
+class TestBlockedPrivateIPs:
+    """Private RFC 1918 and other reserved ranges must be blocked."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://10.0.0.1/",
+            "http://10.255.255.255/",
+            "http://172.16.0.1/",
+            "http://172.31.255.255/",
+            "http://192.168.0.1/",
+            "http://192.168.1.100:8080/admin",
+        ],
+    )
+    def test_rfc1918_blocked(self, url: str):
+        with pytest.raises(SSRFBlockedError):
+            validate_url(url)
+
+    def test_loopback_ip(self):
+        with pytest.raises(SSRFBlockedError):
+            validate_url("http://127.0.0.1:9200/")
+
+    def test_loopback_range(self):
+        with pytest.raises(SSRFBlockedError):
+            validate_url("http://127.0.0.2/")
+
+    def test_link_local(self):
+        with pytest.raises(SSRFBlockedError):
+            validate_url("http://169.254.1.1/")
+
+    def test_zero_network(self):
+        with pytest.raises(SSRFBlockedError):
+            validate_url("http://0.0.0.0/")
+
+    def test_carrier_grade_nat(self):
+        with pytest.raises(SSRFBlockedError):
+            validate_url("http://100.64.0.1/")
+
+
+class TestBlockedHostnames:
+    """Known internal hostnames must be blocked."""
+
+    def test_localhost(self):
+        with pytest.raises(SSRFBlockedError, match="localhost"):
+            validate_url("http://localhost:5432/")
+
+    def test_localhost_https(self):
+        with pytest.raises(SSRFBlockedError):
+            validate_url("https://localhost/admin")
+
+    def test_zero_host(self):
+        with pytest.raises(SSRFBlockedError):
+            validate_url("http://0.0.0.0:8080/")
+
+
+class TestBlockedIPv6:
+    """IPv6 private/reserved ranges must be blocked."""
+
+    def test_ipv6_loopback(self):
+        with pytest.raises(SSRFBlockedError):
+            validate_url("http://[::1]/")
+
+    def test_ipv6_unique_local(self):
+        with pytest.raises(SSRFBlockedError):
+            validate_url("http://[fd00::1]/")
+
+    def test_ipv6_link_local(self):
+        with pytest.raises(SSRFBlockedError):
+            validate_url("http://[fe80::1]/")
+
+
+class TestDNSRebinding:
+    """Hostnames that resolve to private IPs must be blocked."""
+
+    def test_hostname_resolving_to_loopback(self):
+        fake_result = [
+            (2, 1, 6, "", ("127.0.0.1", 0)),
+        ]
+        with patch("core.services.url_guard.socket.getaddrinfo", return_value=fake_result):
+            with pytest.raises(SSRFBlockedError, match="resolves to a private"):
+                validate_url("http://evil-rebind.attacker.com/steal")
+
+    def test_hostname_resolving_to_internal(self):
+        fake_result = [
+            (2, 1, 6, "", ("10.0.0.5", 0)),
+        ]
+        with patch("core.services.url_guard.socket.getaddrinfo", return_value=fake_result):
+            with pytest.raises(SSRFBlockedError):
+                validate_url("http://corporate-proxy.example.com/")
+
+
+class TestValidPublicURLs:
+    """Legitimate public URLs must pass validation."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://github.com/user",
+            "https://example.com/portfolio",
+            "http://blog.example.org/about",
+            "https://1.1.1.1/dns-query",
+            "https://8.8.8.8/",
+        ],
+    )
+    def test_public_url_passes(self, url: str):
+        # Patch DNS resolution to return a public IP
+        fake_result = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        with patch("core.services.url_guard.socket.getaddrinfo", return_value=fake_result):
+            result = validate_url(url)
+            assert result == url
+
+
+class TestMalformedURLs:
+    """Malformed or invalid URLs raise ValueError."""
+
+    def test_no_scheme(self):
+        with pytest.raises(ValueError, match="scheme"):
+            validate_url("ftp://internal.corp/data")
+
+    def test_empty_host(self):
+        with pytest.raises(ValueError, match="hostname"):
+            validate_url("http:///path")
+
+
+# ---------------------------------------------------------------------------
+# Integration: execute_tool fetch_url with SSRF guard
+# ---------------------------------------------------------------------------
+
+
+class TestFetchUrlSSRFIntegration:
+    """Verify that execute_tool('fetch_url', ...) blocks SSRF attempts."""
+
+    @pytest.mark.asyncio
+    async def test_imds_blocked_in_execute_tool(self):
+        from core.config import AppSettings
+        from core.services.agent_tools import execute_tool
+
+        result = await execute_tool(
+            "fetch_url",
+            {"url": "http://169.254.169.254/latest/meta-data/"},
+            settings=AppSettings(),
+        )
+        data = json.loads(result)
+        assert "error" in data
+        assert "SSRF blocked" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_localhost_blocked_in_execute_tool(self):
+        from core.config import AppSettings
+        from core.services.agent_tools import execute_tool
+
+        result = await execute_tool(
+            "fetch_url",
+            {"url": "http://localhost:9200/_cat/indices"},
+            settings=AppSettings(),
+        )
+        data = json.loads(result)
+        assert "error" in data
+        assert "SSRF blocked" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_internal_ip_blocked_in_execute_tool(self):
+        from core.config import AppSettings
+        from core.services.agent_tools import execute_tool
+
+        result = await execute_tool(
+            "fetch_url",
+            {"url": "http://10.0.0.1/admin"},
+            settings=AppSettings(),
+        )
+        data = json.loads(result)
+        assert "error" in data
+        assert "SSRF blocked" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_public_url_still_works(self):
+        """A legitimate public URL should pass the guard and reach httpx."""
+        import httpx
+        from contextlib import asynccontextmanager
+        from core.config import AppSettings
+        from core.services.agent_tools import execute_tool
+
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 200
+        resp.text = "<html><head><title>Portfolio</title></head><body></body></html>"
+        resp.url = httpx.URL("https://example.com/portfolio")
+
+        @asynccontextmanager
+        async def mock_client_cm(*args, **kwargs):
+            client = AsyncMock()
+            client.get = AsyncMock(return_value=resp)
+            yield client
+
+        # Patch DNS to return a public IP so the guard passes
+        fake_dns = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        with patch("core.services.url_guard.socket.getaddrinfo", return_value=fake_dns), \
+             patch("adapters.http_client.build_async_client", mock_client_cm):
+            result = await execute_tool(
+                "fetch_url",
+                {"url": "https://example.com/portfolio"},
+                settings=AppSettings(),
+            )
+
+        data = json.loads(result)
+        assert "error" not in data
+        assert data["status_code"] == 200


### PR DESCRIPTION
Block private/internal/IMDS targets in the agent's fetch_url tool to prevent Server-Side Request Forgery via prompt injection in target profile data.

New module: core/services/url_guard.py
- Blocks known IMDS hostnames (AWS, GCP, Azure)
- Blocks RFC 1918, loopback, link-local, carrier-grade NAT ranges
- Blocks IPv6 private ranges (::1, fc00::/7, fe80::/10)
- DNS resolution check catches rebinding to private IPs
- Raises SSRFBlockedError with clear message

Integration:
- agent_tools.py: validate_url() called before any HTTP request
- 35 new tests covering all blocked categories + integration

Closes #25